### PR TITLE
feat: Add field `destination_data` to `initiate()`

### DIFF
--- a/programs/solana-native-swaps/src/lib.rs
+++ b/programs/solana-native-swaps/src/lib.rs
@@ -22,6 +22,7 @@ pub mod solana_native_swaps {
         expires_in_slots: u64,
         redeemer: Pubkey,
         secret_hash: [u8; 32],
+        destination_data: Option<Vec<u8>>,
     ) -> Result<()> {
         let transfer_context = CpiContext::new(
             ctx.accounts.system_program.to_account_info(),
@@ -46,6 +47,7 @@ pub mod solana_native_swaps {
             initiator: ctx.accounts.initiator.key(),
             redeemer,
             secret_hash,
+            destination_data,
         });
 
         Ok(())
@@ -212,6 +214,8 @@ pub struct Initiated {
     pub initiator: Pubkey,
     pub redeemer: Pubkey,
     pub secret_hash: [u8; 32],
+    /// Information regarding the destination chain in the atomic swap.
+    pub destination_data: Option<Vec<u8>>,
 }
 /// Represents the redeemed state of the swap, where the redeemer has withdrawn funds from the vault
 #[event]

--- a/tests/solana-native-swaps.ts
+++ b/tests/solana-native-swaps.ts
@@ -31,13 +31,20 @@ describe("Testing one way swap between Alice and Bob", () => {
     pdaSeeds,
     program.programId
   );
+  const destinationData = crypto.randomBytes(256); // can be null
   let rentAmount: number;
 
   console.log({ alice: alice.publicKey, bob: bob.publicKey, swapAccount });
 
   const aliceInitiate = async () => {
     const initSignature = await program.methods
-      .initiate(swapAmount, expiresInSlots, bob.publicKey, [...secretHash])
+      .initiate(
+        swapAmount,
+        expiresInSlots,
+        bob.publicKey,
+        [...secretHash],
+        destinationData
+      )
       .accounts({
         initiator: alice.publicKey,
       })


### PR DESCRIPTION
Since this program will be participating in an atomic swap that involves two different chains, this field of type `Vec<u8>` shall store additional information regarding the target chain.

The contract doesn't act on this data, it merely emits this in its events, allowing for listeners to have context directly from the chain, rather than from an off-chain source.