### PR TITLE
Introduce sponsor for rent payment and refund

### DIFF
--- a/programs/solana-native-swaps/src/lib.rs
+++ b/programs/solana-native-swaps/src/lib.rs
@@ -38,6 +38,7 @@ pub mod solana_native_swaps {
             initiator: ctx.accounts.initiator.key(),
             redeemer,
             secret_hash,
+            sponsor: ctx.accounts.sponsor.key(),
         };
 
         emit!(Initiated {
@@ -121,6 +122,9 @@ pub struct SwapAccount {
     redeemer: Pubkey,
     /// The secret hash associated with the atomic swap
     secret_hash: [u8; 32],
+    /// The entity that paid the rent fees for the creation of this PDA.
+    /// This will be referenced during the refund of the same upon closing this PDA.
+    pub sponsor: Pubkey,
 }
 
 #[derive(Accounts)]
@@ -136,7 +140,7 @@ pub struct Initiate<'info> {
     /// This PDA will be deleted upon completion of the swap.
     #[account(
         init,
-        payer = initiator,
+        payer = sponsor,
         seeds = [b"swap_account", initiator.key().as_ref(), &secret_hash],
         bump,
         space = ANCHOR_DISCRIMINATOR + SwapAccount::INIT_SPACE,
@@ -147,25 +151,31 @@ pub struct Initiate<'info> {
     #[account(mut)]
     pub initiator: Signer<'info>,
 
+    /// Any entity that pays the PDA rent.
+    /// Upon completion of the swap, the PDA rent refund resulting from the
+    /// deletion of `swap_account` will be refunded to this address.
+    #[account(mut)]
+    pub sponsor: Signer<'info>,
+
     pub system_program: Program<'info, System>,
 }
 
 #[derive(Accounts)]
+#[instruction(secret: [u8; 32])]
 pub struct Redeem<'info> {
     /// The PDA holding the state information of the atomic swap.
     /// Will be closed upon successful execution and the resulting rent
     /// will be transferred to the initiator.
-    #[account(mut, close = initiator)]
+    #[account(mut, close = sponsor)]
     pub swap_account: Account<'info, SwapAccount>,
-
-    /// CHECK: Verifying the initiator.  
-    /// This is included here for the PDA rent refund using the `close` attribute above.
-    #[account(mut, address = swap_account.initiator @ SwapError::InvalidInitiator)]
-    pub initiator: AccountInfo<'info>,
 
     /// CHECK: Verifying the redeemer
     #[account(mut, address = swap_account.redeemer @ SwapError::InvalidRedeemer)]
     pub redeemer: AccountInfo<'info>,
+
+    /// CHECK: Sponsor's address for refunding PDA rent
+    #[account(mut, address = swap_account.sponsor @ SwapError::InvalidSponsor)]
+    pub sponsor: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]
@@ -173,13 +183,16 @@ pub struct Refund<'info> {
     /// The PDA holding the state information of the atomic swap.
     /// Will be closed upon successful execution and the resulting rent
     /// will be transferred to the initiator.
-    #[account(mut, close = initiator)]
+    #[account(mut, close = sponsor)]
     pub swap_account: Account<'info, SwapAccount>,
 
-    /// CHECK: Verifying the initiator.
-    /// This is included here for the PDA rent refund using the `close` attribute above.
+    /// CHECK: The initiator of the swap.
     #[account(mut, address = swap_account.initiator @ SwapError::InvalidInitiator)]
     pub initiator: AccountInfo<'info>,
+
+    /// CHECK: Sponsor's address for refunding PDA rent
+    #[account(mut, address = swap_account.sponsor @ SwapError::InvalidSponsor)]
+    pub sponsor: AccountInfo<'info>,
 }
 
 #[derive(Accounts)]
@@ -187,17 +200,20 @@ pub struct InstantRefund<'info> {
     /// The PDA holding the state information of the atomic swap.
     /// Will be closed upon successful execution and the resulting rent
     /// will be transferred to the initiator.
-    #[account(mut, close = initiator)]
+    #[account(mut, close = sponsor)]
     pub swap_account: Account<'info, SwapAccount>,
 
-    /// CHECK: Verifying the initiator.
-    /// This is included here for the PDA rent refund using the `close` attribute above.
+    /// CHECK: The initiator of the swap.
     #[account(mut, address = swap_account.initiator @ SwapError::InvalidInitiator)]
     pub initiator: AccountInfo<'info>,
 
-    /// CHECK: Verifying the redeemer. Redeemer must sign this transaction.
+    /// CHECK: The redeemer of the swap. They must sign this transaction.
     #[account(address = swap_account.redeemer @ SwapError::InvalidRedeemer)]
     pub redeemer: Signer<'info>,
+
+    /// CHECK: Sponsor's address for PDA rent refund
+    #[account(mut, address = swap_account.sponsor @ SwapError::InvalidSponsor)]
+    pub sponsor: AccountInfo<'info>,
 }
 
 /// Represents the initiated state of the swap where the initiator has deposited funds into the vault
@@ -243,6 +259,9 @@ pub enum SwapError {
 
     #[msg("The provided secret does not correspond to the secret hash of this swap")]
     InvalidSecret,
+
+    #[msg("The provided sponsor is not the original sponsor of this swap")]
+    InvalidSponsor,
 
     #[msg("Attempt to perform a refund before expiry time")]
     RefundBeforeExpiry,

--- a/tests/solana-native-swaps.ts
+++ b/tests/solana-native-swaps.ts
@@ -21,6 +21,8 @@ describe("Testing one way swap between Alice and Bob", () => {
   // Bob is the redeemer here
   const bob = web3.Keypair.fromSeed(crypto.randomBytes(32));
 
+  const sponsor = new web3.Keypair();
+
   // SwapAccount PDA
   const pdaSeeds = [
     Buffer.from("swap_account"),
@@ -40,8 +42,9 @@ describe("Testing one way swap between Alice and Bob", () => {
       .initiate(swapAmount, expiresInSlots, bob.publicKey, [...secretHash])
       .accounts({
         initiator: alice.publicKey,
+        sponsor: sponsor.publicKey,
       })
-      .signers([alice])
+      .signers([alice, sponsor])
       .rpc({ commitment: "confirmed" });
     console.log("Alice initiated:", initSignature);
   };
@@ -58,10 +61,17 @@ describe("Testing one way swap between Alice and Bob", () => {
       1 * web3.LAMPORTS_PER_SOL
     );
     await connection.confirmTransaction({ signature, ...blockHash });
+    console.log("Fund sponsor with 0.1 SOL");
+    signature = await connection.requestAirdrop(
+      sponsor.publicKey,
+      0.1 * web3.LAMPORTS_PER_SOL
+    );
+    await connection.confirmTransaction({ signature, ...blockHash });
   });
 
   it("Test initiation", async () => {
     const alicePreBalance = await connection.getBalance(alice.publicKey);
+    const sponsorPreBalance = await connection.getBalance(sponsor.publicKey);
 
     await aliceInitiate();
 
@@ -69,20 +79,22 @@ describe("Testing one way swap between Alice and Bob", () => {
     expect(pdaBalance).to.equal(rentAmount + swapAmount.toNumber());
 
     const alicePostBalance = await connection.getBalance(alice.publicKey);
-    expect(alicePostBalance).to.equal(
-      alicePreBalance - swapAmount.toNumber() - rentAmount
-    );
+    expect(alicePostBalance).to.equal(alicePreBalance - swapAmount.toNumber());
+
+    const sponsorPostBalance = await connection.getBalance(sponsor.publicKey);
+    expect(sponsorPostBalance).to.equal(sponsorPreBalance - rentAmount);
   });
 
   it("Test redeem", async () => {
     const bobPreBalance = await connection.getBalance(bob.publicKey);
+    const sponsorPreBalance = await connection.getBalance(sponsor.publicKey);
 
     // The previous test has already initiated the swap
     const redeemSignature = await program.methods
       .redeem([...secret])
       .accounts({
         swapAccount,
-        initiator: alice.publicKey,
+        sponsor: sponsor.publicKey,
         redeemer: bob.publicKey,
       })
       .rpc();
@@ -93,12 +105,16 @@ describe("Testing one way swap between Alice and Bob", () => {
 
     const pdaBalance = await connection.getBalance(swapAccount);
     expect(pdaBalance).to.equal(0);
+
+    const sponsorPostBalance = await connection.getBalance(sponsor.publicKey);
+    expect(sponsorPostBalance).to.equal(sponsorPreBalance + rentAmount);
   });
 
   it("Test refund", async () => {
     await aliceInitiate(); // Initiate again for the test
 
     const alicePreBalance = await connection.getBalance(alice.publicKey);
+    const sponsorPreBalance = await connection.getBalance(sponsor.publicKey);
 
     console.log("Awaiting timelock for refund");
     await setTimeout(expiresInSlots.toNumber() * 400 + 500);
@@ -108,23 +124,26 @@ describe("Testing one way swap between Alice and Bob", () => {
       .accounts({
         swapAccount,
         initiator: alice.publicKey,
+        sponsor: sponsor.publicKey,
       })
       .rpc({ commitment: "confirmed" });
     console.log("Alice refunded:", refundSignature);
 
     const alicePostBalance = await connection.getBalance(alice.publicKey);
-    expect(alicePostBalance).to.equal(
-      alicePreBalance + swapAmount.toNumber() + rentAmount
-    );
+    expect(alicePostBalance).to.equal(alicePreBalance + swapAmount.toNumber());
 
     const pdaBalance = await connection.getBalance(swapAccount);
     expect(pdaBalance).to.equal(0);
+
+    const sponsorPostBalance = await connection.getBalance(sponsor.publicKey);
+    expect(sponsorPostBalance).to.equal(sponsorPreBalance + rentAmount);
   });
 
   it("Test instant refund", async () => {
     await aliceInitiate(); // Initiate again for the test
 
     const alicePreBalance = await connection.getBalance(alice.publicKey);
+    const sponsorPreBalance = await connection.getBalance(sponsor.publicKey);
 
     const instantRefundSignature = await program.methods
       .instantRefund()
@@ -132,17 +151,19 @@ describe("Testing one way swap between Alice and Bob", () => {
         swapAccount,
         initiator: alice.publicKey,
         redeemer: bob.publicKey,
+        sponsor: sponsor.publicKey,
       })
       .signers([bob])
       .rpc();
     console.log("Alice instant-refunded:", instantRefundSignature);
 
     const alicePostBalance = await connection.getBalance(alice.publicKey);
-    expect(alicePostBalance).to.equal(
-      alicePreBalance + swapAmount.toNumber() + rentAmount
-    );
+    expect(alicePostBalance).to.equal(alicePreBalance + swapAmount.toNumber());
 
     const pdaBalance = await connection.getBalance(swapAccount);
     expect(pdaBalance).to.equal(0);
+
+    const sponsorPostBalance = await connection.getBalance(sponsor.publicKey);
+    expect(sponsorPostBalance).to.equal(sponsorPreBalance + rentAmount);
   });
 });


### PR DESCRIPTION
Sponsor shall pay the rent for the PDA created during initiate. After
a successful swap sequence, this PDA will be deleted and the resulting
rent refund shall be returned to the same.